### PR TITLE
Dość

### DIFF
--- a/template/webpage.html
+++ b/template/webpage.html
@@ -1,59 +1,60 @@
 <!DOCTYPE html>
 <html lang="pl">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-    <title>
-        {{ title }}
-    </title>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <title>
+    {{ title }}
+  </title>
 </head>
 
 <style>
-    body {
-        background-color: #f8f9fa;
-        color: #343a40;
-    }
+  body {
+    background-color: #f8f9fa;
+    color: #343a40;
+  }
 </style>
 
 <body>
-<div class="container">
+  <div class="container">
     <div class="row">
-        <div class="col-12">
-            <h1 class="text-center">
-                {{ title }}
-            </h1>
-        </div>
+      <div class="col-12">
+        <h1 class="text-center">
+          {{ title }}
+        </h1>
+      </div>
     </div>
     {% for project in projects %}
-    <hr/>
+    <hr />
     <div class="row">
-        <div class="col-12">
-            <h2>
-                {{ project.title }}
-                {% if project.author %}- {{ project.author }}{% endif %}
-            </h2>
-            {% for image in project.images %}
-            <img src="{{ image }}" class="img-fluid" alt="{{ project.name }}">
-            {% endfor %}
-            {% if project.description %}
-            <p>
-                {{ project.description }}
-            </p>
-            {% endif %}
-            {% if project.url %}
-            <p>
-                <a href="{{ project.url }}" class="btn btn-primary">
-                    Zobacz projekt
-                </a>
-            </p>
-            {% endif %}
-        </div>
+      <div class="col-12">
+        <h2>
+          {{ project.title }}
+          {% if project.author %}- {{ project.author }}{% endif %}
+        </h2>
+        {% for image in project.images %}
+        <img src="{{ image }}" class="img-fluid" alt="{{ project.name }}">
+        {% endfor %}
+        {% if project.description %}
+        <p>
+          {{ project.description }}
+        </p>
+        {% endif %}
+        {% if project.url %}
+        <p>
+          <a href="{{ project.url }}" class="btn btn-primary">
+            Zobacz projekt
+          </a>
+        </p>
+        {% endif %}
+      </div>
     </div>
     {% endfor %}
-</div>
+  </div>
 </body>
 
 </html>

--- a/template/webpage.html
+++ b/template/webpage.html
@@ -5,55 +5,80 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
   <title>
     {{ title }}
   </title>
 </head>
 
-<style>
-  body {
-    background-color: #f8f9fa;
-    color: #343a40;
-  }
-</style>
-
 <body>
-  <div class="container">
-    <div class="row">
-      <div class="col-12">
-        <h1 class="text-center">
-          {{ title }}
-        </h1>
-      </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js"
+    integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+"
+    crossorigin="anonymous"></script>
+  <div class="container-xxl pb-4">
+    <div class="row bg-light my-3 p-2 mx-0 rounded">
+      <h1 class="text-center font-monospace m-0">
+        {{ title }}
+      </h1>
     </div>
-    {% for project in projects %}
-    <hr />
-    <div class="row">
-      <div class="col-12">
-        <h2>
-          {{ project.title }}
-          {% if project.author %}- {{ project.author }}{% endif %}
-        </h2>
-        {% for image in project.images %}
-        <img src="{{ image }}" class="img-fluid" alt="{{ project.name }}">
-        {% endfor %}
-        {% if project.description %}
-        <p>
-          {{ project.description }}
-        </p>
-        {% endif %}
-        {% if project.url %}
-        <p>
-          <a href="{{ project.url }}" class="btn btn-primary">
-            Zobacz projekt
-          </a>
-        </p>
-        {% endif %}
+    <div class="row row-cols-1 row-cols-lg-2 g-3">
+      {% for project in projects %}
+      {% set project_id = loop.index %}
+      <div class="col">
+        <div class="card h-100">
+          <div id="carousel{{ project_id }}" class="carousel slide card-img-top">
+            {% if project.images|length > 1 %}
+            <div class="carousel-indicators">
+              {% for image in project.images %}
+              <button type="button" data-bs-target="#carousel{{ project_id }}" data-bs-slide-to="{{ loop.index0 }}" {%
+                if loop.first %}class="active" {% endif %}></button>
+              {% endfor %}
+            </div>
+            {% endif %}
+            <div class="carousel-inner">
+              {% for image in project.images %}
+              <div class="carousel-item {% if loop.first %}active{% endif %}">
+                <img src="{{ image }}" class="d-block w-100" alt="{{ project.name }}">
+              </div>
+              {% endfor %}
+            </div>
+            {% if project.images|length > 1 %}
+            <button class="carousel-control-prev" type="button" data-bs-target="#carousel{{ project_id }}"
+              data-bs-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Poprzedni</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#carousel{{ project_id }}"
+              data-bs-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Następny</span>
+            </button>
+            {% endif %}
+          </div>
+          <div class="card-body pb-0">
+            <h3 class="card-title {% if project.author %}mb-1{% else %}mb-3{% endif %}">
+              {% if project.url %}
+              <a href="{{ project.url }}" class="text-decoration-none">
+                {{ project.title }}
+              </a>
+              {% else %}
+              {{ project.title }}
+              {% endif %}
+            </h3>
+            {% if project.author %}
+            <p class="text-body-secondary">{{ project.author }}</p>
+            {% endif %}
+            {% if project.description %}
+            <p>
+              {{ project.description }}
+            </p>
+            {% endif %}
+          </div>
+        </div>
       </div>
+      {% endfor %}
     </div>
-    {% endfor %}
   </div>
 </body>
 

--- a/template/webpage.html
+++ b/template/webpage.html
@@ -27,35 +27,57 @@
       {% set project_id = loop.index %}
       <div class="col">
         <div class="card h-100">
-          <div id="carousel{{ project_id }}" class="carousel slide card-img-top">
+          {% macro carousel(carousel_id_suff, img_classes, img_target) %}
+          {% set carousel_id = 'carousel' ~ project_id ~ '-' ~ carousel_id_suff %}
+          <div id="{{ carousel_id }}" class="carousel slide">
             {% if project.images|length > 1 %}
             <div class="carousel-indicators">
               {% for image in project.images %}
-              <button type="button" data-bs-target="#carousel{{ project_id }}" data-bs-slide-to="{{ loop.index0 }}" {%
-                if loop.first %}class="active" {% endif %}></button>
+              <button type="button" data-bs-target="#{{ carousel_id }}" data-bs-slide-to="{{ loop.index0 }}" {% if
+                loop.first %}class="active" {% endif %}></button>
               {% endfor %}
             </div>
             {% endif %}
             <div class="carousel-inner">
               {% for image in project.images %}
               <div class="carousel-item {% if loop.first %}active{% endif %}">
-                <img src="{{ image }}" class="d-block w-100" alt="{{ project.name }}">
+                <div class="d-none d-lg-block">
+                  {% if img_target %}<a href="#" data-bs-toggle="modal" data-bs-target="#{{ img_target }}">{% endif %}
+                    <img src="{{ image }}" class="{{ img_classes }}" alt="{{ project.name }}">
+                    {% if img_target %}</a>{% endif %}
+                </div>
+                <div class="d-lg-none">
+                  <img src="{{ image }}" class="{{ img_classes }}" alt="{{ project.name }}">
+                </div>
               </div>
               {% endfor %}
             </div>
             {% if project.images|length > 1 %}
-            <button class="carousel-control-prev" type="button" data-bs-target="#carousel{{ project_id }}"
+            <button class=" carousel-control-prev" type="button" data-bs-target="#{{ carousel_id }}"
               data-bs-slide="prev">
               <span class="carousel-control-prev-icon" aria-hidden="true"></span>
               <span class="visually-hidden">Poprzedni</span>
             </button>
-            <button class="carousel-control-next" type="button" data-bs-target="#carousel{{ project_id }}"
+            <button class="carousel-control-next" type="button" data-bs-target="#{{ carousel_id }}"
               data-bs-slide="next">
               <span class="carousel-control-next-icon" aria-hidden="true"></span>
               <span class="visually-hidden">Następny</span>
             </button>
             {% endif %}
           </div>
+          {% endmacro %}
+
+          {% set modal_id = 'modal' ~ project_id ~ '-' ~ loop.index0 %}
+          {{ carousel(0, 'd-block w-100 card-img-top', modal_id) }}
+
+          <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-xl">
+              <div class="modal-content">
+                {{ carousel(1, 'd-block w-100', '') }}
+              </div>
+            </div>
+          </div>
+
           <div class="card-body pb-0">
             <h3 class="card-title {% if project.author %}mb-1{% else %}mb-3{% endif %}">
               {% if project.url %}

--- a/template/webpage.html
+++ b/template/webpage.html
@@ -10,6 +10,13 @@
   <title>
     {{ title }}
   </title>
+
+  <style>
+    .modal-img {
+      max-width: 90vw;
+      max-height: 90vh;
+    }
+  </style>
 </head>
 
 <body>
@@ -27,8 +34,7 @@
       {% set project_id = loop.index %}
       <div class="col">
         <div class="card h-100">
-          {% macro carousel(carousel_id_suff, img_classes, img_target) %}
-          {% set carousel_id = 'carousel' ~ project_id ~ '-' ~ carousel_id_suff %}
+          {% set carousel_id = 'carousel' ~ project_id %}
           <div id="{{ carousel_id }}" class="carousel slide">
             {% if project.images|length > 1 %}
             <div class="carousel-indicators">
@@ -42,12 +48,20 @@
               {% for image in project.images %}
               <div class="carousel-item {% if loop.first %}active{% endif %}">
                 <div class="d-none d-lg-block">
-                  {% if img_target %}<a href="#" data-bs-toggle="modal" data-bs-target="#{{ img_target }}">{% endif %}
-                    <img src="{{ image }}" class="{{ img_classes }}" alt="{{ project.name }}">
-                    {% if img_target %}</a>{% endif %}
+                  {% set modal_id = 'modal' ~ project_id ~ '-' ~ loop.index0 %}
+                  <a href="#" data-bs-toggle="modal" data-bs-target="#{{ modal_id}}">
+                    <img src="{{ image }}" class="d-block w-100 card-img-top" alt="{{ project.name }}">
+                  </a>
+                  <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered w-auto mw-100">
+                      <div class="m-auto">
+                        <img src="{{ image }}" class="modal-img" alt="{{ project.name }}">
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 <div class="d-lg-none">
-                  <img src="{{ image }}" class="{{ img_classes }}" alt="{{ project.name }}">
+                  <img src="{{ image }}" class="d-block w-100 card-img-top" alt="{{ project.name }}">
                 </div>
               </div>
               {% endfor %}
@@ -64,18 +78,6 @@
               <span class="visually-hidden">Następny</span>
             </button>
             {% endif %}
-          </div>
-          {% endmacro %}
-
-          {% set modal_id = 'modal' ~ project_id ~ '-' ~ loop.index0 %}
-          {{ carousel(0, 'd-block w-100 card-img-top', modal_id) }}
-
-          <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered modal-xl">
-              <div class="modal-content">
-                {{ carousel(1, 'd-block w-100', '') }}
-              </div>
-            </div>
           </div>
 
           <div class="card-body pb-0">

--- a/template/webpage.html
+++ b/template/webpage.html
@@ -82,13 +82,7 @@
 
           <div class="card-body pb-0">
             <h3 class="card-title {% if project.author %}mb-1{% else %}mb-3{% endif %}">
-              {% if project.url %}
-              <a href="{{ project.url }}" class="text-decoration-none">
-                {{ project.title }}
-              </a>
-              {% else %}
               {{ project.title }}
-              {% endif %}
             </h3>
             {% if project.author %}
             <p class="text-body-secondary">{{ project.author }}</p>
@@ -97,6 +91,9 @@
             <p>
               {{ project.description }}
             </p>
+            {% endif %}
+            {% if project.url %}
+            <p><a href="{{ project.url }}" class="text-decoration-none mb-2">Strona projektu</a></p>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
Jeżeli szerokość ekranu wynosi przynajmniej 992px, projekty wyświetlają się w dwóch kolumnach. Jeżeli projekt ma więcej niż jedno zdjęcie, wyświetlają się w karuzeli. Po kliknięciu na zdjęcie pojawia się na środku na cały ekran (dokładniej w oryginalnej rozdzielczości, chyba, że jest większa niż 90% wysokości lub 90% szerokości ekranu). Próbowałem robić karuzele na cały ekran, ale to kiepsko działało.

Jeżeli szerokość ekranu jest mniejsza niż 992px, projekty wyświetlają się w jednej kolumnie. Klikanie w zdjęcia nie daje już żadnego efektu - nie da się wyświetlić ich szerszych niż już są.

Karuzele działają gorzej, jeśli zdjęcia w nich mają różne proporcje (karta zmienia rozmiar). Wolałbym się tym jednak martwić później, dopiero, gdy ktoś takie wyśle. A przynajmniej nie dzisiaj.

![Zrzut ekranu z 2024-02-14 o 21 09 18](https://github.com/tudny/GK-projects-repository/assets/29335183/c0d7459c-95b7-4caf-a3c8-60c75fd075a9)

![Zrzut ekranu z 2024-02-14 o 21 09 21](https://github.com/tudny/GK-projects-repository/assets/29335183/63bd9ff6-17d0-4aed-8415-bdc5fa1076b8)

![Zrzut ekranu z 2024-02-14 o 21 09 28](https://github.com/tudny/GK-projects-repository/assets/29335183/fd7c0d24-e332-4c07-ab5f-f4c8803ea71a)

![Zrzut ekranu z 2024-02-14 o 21 10 13](https://github.com/tudny/GK-projects-repository/assets/29335183/4f2855c9-2f3f-460e-b6ae-27a1ce38a57e)